### PR TITLE
cargo deb on build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,3 +20,9 @@ jobs:
     - uses: actions/checkout@v4
     - name: Build
       run: cargo build --release --verbose
+
+    - name: Install cargo-deb
+      run: cargo install cargo-deb
+
+    - name: Build deb
+      run: cargo deb


### PR DESCRIPTION
### TL;DR

Added Debian package building to the GitHub Actions workflow.

### What changed?

- Added two new steps to the existing GitHub Actions workflow:
  1. Install `cargo-deb` using `cargo install cargo-deb`
  2. Build a Debian package using `cargo deb`

### Why make this change?

To automate the creation of Debian packages as part of the CI/CD pipeline, making it easier to distribute the software to Debian-based systems and streamline the release process.