### PR TITLE
removed triage from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 <p align="center">
-<a href="">
+<a href="https://crates.io/crates/sticks" rel="noopener noreferrer">
 <img src="sticks.png" alt="sticks Logo" height="150" width="150"/>
 </a>
 </p>
 <h1 align="center">sticks</h1>
-
-[![Open Source Helpers](https://www.codetriage.com/maminechniti/sticks/badges/users.svg)](https://www.codetriage.com/maminechniti/sticks)
 
 Sticks is a Rust command-line tool for managing C and C++ projects. It simplifies the process of creating new projects and managing dependencies in your Makefile.
 


### PR DESCRIPTION
### TL;DR

Updated README.md with crates.io link and removed CodeTriage badge.

### What changed?

- Added a link to the crates.io page for the sticks project in the logo image.
- Removed the CodeTriage badge from the README.

### Why make this change?

- Adding the crates.io link improves discoverability and provides easy access to the project's package information.
- Removing the CodeTriage badge simplifies the README and focuses on more essential project information.