### PR TITLE
trying to fix multiple dependencies adding and removal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub mod languages;
 pub mod sources;
 pub mod updater;
 
-pub use dependencies::{add_dependency, remove_dependency};
+pub use dependencies::{add_dependencies, remove_dependencies};
 pub use file_handler::create_dir;
 pub use languages::{Language, LanguageConsts};
 pub use sources::add_sources;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@
 use clap::{App, Arg, SubCommand};
 use std::env;
 use sticks::{
-	add_dependency, add_sources, init_project, new_project, remove_dependency, update_project,
+	add_dependencies, add_sources, init_project, new_project, remove_dependencies, update_project,
 	Language,
 };
 
@@ -33,7 +33,11 @@ fn main() {
 		.subcommand(
 			SubCommand::with_name("add")
 				.about("Add dependencies to the Makefile")
-				.arg(Arg::with_name("dependency_name").required(true)),
+				.arg(
+					Arg::with_name("dependency_name")
+						.required(true)
+						.multiple(true),
+				),
 		)
 		.subcommand(
 			SubCommand::with_name("remove")
@@ -86,17 +90,23 @@ fn main() {
 			}
 		}
 		("add", Some(sub_m)) => {
-			if let Err(e) = add_dependency(sub_m.value_of("dependency_name").unwrap()) {
+			let dependencies: Vec<String> = sub_m
+				.values_of("dependency_name")
+				.unwrap()
+				.map(|s| s.to_string())
+				.collect();
+			if let Err(e) = add_dependencies(&dependencies) {
 				eprintln!("Error: {}", e);
 				std::process::exit(1);
 			}
 		}
 		("remove", Some(sub_m)) => {
-			let dependencies: Vec<&str> = sub_m
+			let dependencies: Vec<String> = sub_m
 				.values_of("dependency_name")
-				.unwrap_or_default()
+				.unwrap()
+				.map(|s| s.to_string())
 				.collect();
-			if let Err(e) = remove_dependency(&dependencies) {
+			if let Err(e) = remove_dependencies(&dependencies) {
 				eprintln!("Error: {}", e);
 				std::process::exit(1);
 			}


### PR DESCRIPTION
### TL;DR

Enhanced dependency management in the Makefile with support for multiple dependencies.

### What changed?

- Refactored `add_dependency` to `add_dependencies`, allowing multiple dependencies to be added at once.
- Updated `remove_dependency` to `remove_dependencies`, supporting removal of multiple dependencies simultaneously.
- Improved handling of the `install-deps` rule in the Makefile, including better cleanup when all dependencies are removed.
- Updated the CLI interface to accept multiple dependencies for both add and remove commands.

### Why make this change?

This change improves the flexibility and efficiency of managing dependencies in the Makefile. By allowing users to add or remove multiple dependencies in a single command, it reduces the number of operations needed for dependency management. The improved handling of the `install-deps` rule also ensures better Makefile maintenance, removing unnecessary rules when all dependencies are removed.