### PR TITLE
host err

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -108,8 +108,8 @@ if (-not (Get-Command rustc -ErrorAction SilentlyContinue)) {
 
 # Get the host value from rustc output
 $rustcOutput = rustc -vV
-$hostLine = $rustcOutput | Where-Object { $_ -like "host:*" }
-$host = ($hostLine -split ' ')[1]
+$rustHostLine = $rustcOutput | Where-Object { $_ -like "host:*" }
+$rustHost = ($rustHostLine -split ' ')[1]
 
 # Create a temporary directory
 $tempDir = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ("sticks_install_" + (Get-Random))


### PR DESCRIPTION
### TL;DR

Improved variable naming in Rust host detection for PowerShell installation script.

### What changed?

- Renamed `$hostLine` to `$rustHostLine` for clarity.
- Renamed `$host` to `$rustHost` to avoid potential conflicts with PowerShell's built-in `$host` variable.

### Why make this change?

This change enhances code readability and prevents potential issues with variable naming. By using more specific variable names, we reduce the risk of conflicts with built-in PowerShell variables and improve the overall maintainability of the script.