### PR TITLE
another host err

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -27,7 +27,6 @@ function Compare-Version {
 
     for ($i = 0; $i -lt $ver1Parts.Length; $i++) {
         if ($ver2Parts.Length -le $i) {
-            # If ver2 has fewer components, consider it smaller
             return $true
         }
         if ([int]$ver1Parts[$i] -gt [int]$ver2Parts[$i]) {


### PR DESCRIPTION
### TL;DR

Simplified version comparison logic in PowerShell install script.

### What changed?

Removed a comment explaining the behavior when `ver2` has fewer components than `ver1` in the `Compare-Version` function. The logic remains the same, but the explanatory comment has been eliminated.

### Why make this change?

The removed comment was redundant as the code's behavior is self-explanatory. Eliminating unnecessary comments helps maintain cleaner, more concise code without affecting functionality.