### PR TITLE
sticks version not sticks -v

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -60,7 +60,7 @@ function Get-LatestVersion {
 # Function to get the installed version of sticks
 function Get-InstalledVersion {
     try {
-        $localVersionOutput = sticks -v
+        $localVersionOutput = sticks version
         if ($localVersionOutput -match "^sticks\s(\d+\.\d+\.\d+)$") {
             return $matches[1]
         }

--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,7 @@ function version_gt {
 }
 
 # Get the version from the output of sticks -v
-local_version=$(sticks -v 2>/dev/null || true)
+local_version=$(sticks version 2>/dev/null || true)
 if [[ "$local_version" =~ ^sticks\ [0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     local_version=$(echo "$local_version" | cut -d ' ' -f 2)
     # Fetch the version from Cargo.toml in the repository
@@ -167,4 +167,4 @@ cd
 rm -rf "$temp_dir"
 
 # Optionally, you can print a message to confirm the installation
-echo "$(sticks -v) is now installed."
+echo "$(sticks version) is now installed."

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -21,7 +21,8 @@ pub fn update_project() -> Result<()> {
 
 	let status = if os == "windows" {
 		std::process::Command::new("cmd")
-			.args(["/C", &update_command])
+			.arg("/C")
+			.arg(&update_command)
 			.status()?
 	} else {
 		std::process::Command::new("sh")
@@ -36,4 +37,3 @@ pub fn update_project() -> Result<()> {
 
 	Ok(())
 }
-


### PR DESCRIPTION
### TL;DR

Updated the version command and improved installation scripts.

### What changed?

- Modified `install.ps1` and `install.sh` to use `sticks version` instead of `sticks -v` for version checking.
- Updated the `updater.rs` file to use separate `.arg()` calls for Windows command execution.

### Why make this change?

The change from `sticks -v` to `sticks version` provides a more consistent and explicit way to retrieve the version information. This aligns with common CLI conventions and improves the overall user experience. The update to the Windows command execution in `updater.rs` enhances reliability and maintainability of the code.