### PR TITLE
powershell -c instead of cmd /c

### DIFF
--- a/src/updater.rs
+++ b/src/updater.rs
@@ -9,10 +9,7 @@ pub fn update_project() -> Result<()> {
 
 	let update_command = match os {
 		"linux" | "macos" => format!("curl -fsSL {} | bash", UPDATE_SCRIPT_URL_LINUX),
-		"windows" => format!(
-			"powershell -Command \"& {{ iwr -useb {} | iex }}\"",
-			UPDATE_SCRIPT_URL_WINDOWS
-		),
+		"windows" => format!("& {{ iwr -useb {} | iex }}", UPDATE_SCRIPT_URL_WINDOWS),
 		_ => {
 			eprintln!("Unsupported operating system: {}", os);
 			return Ok(());
@@ -20,9 +17,9 @@ pub fn update_project() -> Result<()> {
 	};
 
 	let status = if os == "windows" {
-		std::process::Command::new("cmd")
-			.arg("/C")
-			.arg(&update_command)
+		std::process::Command::new("powershell")
+			.arg("-Command")
+			.arg(update_command)
 			.status()?
 	} else {
 		std::process::Command::new("sh")
@@ -37,3 +34,4 @@ pub fn update_project() -> Result<()> {
 
 	Ok(())
 }
+


### PR DESCRIPTION
### TL;DR

Improved Windows update command execution for better compatibility and reliability.

### What changed?

- Modified the Windows update command to use PowerShell directly instead of cmd.
- Simplified the PowerShell command string by removing unnecessary quotes and curly braces.
- Updated the `std::process::Command` for Windows to use "powershell" as the executable and "-Command" as the argument.

### Why make this change?

This change improves the reliability and consistency of the update process on Windows systems. By using PowerShell directly instead of cmd, we ensure better compatibility with modern Windows environments and reduce potential issues related to command interpretation. The simplified command string also enhances readability and maintainability of the code.