### PR TITLE
sticks --version not sticks version

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -60,7 +60,7 @@ function Get-LatestVersion {
 # Function to get the installed version of sticks
 function Get-InstalledVersion {
     try {
-        $localVersionOutput = sticks version
+        $localVersionOutput = sticks --version
         if ($localVersionOutput -match "^sticks\s(\d+\.\d+\.\d+)$") {
             return $matches[1]
         }

--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,7 @@ function version_gt {
 }
 
 # Get the version from the output of sticks -v
-local_version=$(sticks version 2>/dev/null || true)
+local_version=$(sticks --version 2>/dev/null || true)
 if [[ "$local_version" =~ ^sticks\ [0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     local_version=$(echo "$local_version" | cut -d ' ' -f 2)
     # Fetch the version from Cargo.toml in the repository
@@ -167,4 +167,4 @@ cd
 rm -rf "$temp_dir"
 
 # Optionally, you can print a message to confirm the installation
-echo "$(sticks version) is now installed."
+echo "$(sticks --version) is now installed."


### PR DESCRIPTION
### TL;DR

Updated the version command from `sticks version` to `sticks --version` in installation scripts.

### What changed?

- Modified `install.ps1` and `install.sh` to use `sticks --version` instead of `sticks version` when checking for the installed version.
- Updated the final installation confirmation message in `install.sh` to use the new command.

### Why make this change?

This change aligns the version command with common CLI conventions, where `--version` is typically used to display version information. It improves consistency and user experience across different command-line tools.