### PR TITLE
fuck windows

### DIFF
--- a/src/updater.rs
+++ b/src/updater.rs
@@ -9,7 +9,10 @@ pub fn update_project() -> Result<()> {
 
 	let update_command = match os {
 		"linux" | "macos" => format!("curl -fsSL {} | bash", UPDATE_SCRIPT_URL_LINUX),
-		"windows" => format!("& {{ iwr -useb {} | iex }}", UPDATE_SCRIPT_URL_WINDOWS),
+		"windows" => format!(
+			"iex ((New-Object System.Net.WebClient).DownloadString('{}'))",
+			UPDATE_SCRIPT_URL_WINDOWS
+		),
 		_ => {
 			eprintln!("Unsupported operating system: {}", os);
 			return Ok(());
@@ -34,4 +37,3 @@ pub fn update_project() -> Result<()> {
 
 	Ok(())
 }
-


### PR DESCRIPTION
### TL;DR

Updated the Windows update command to use a more secure PowerShell method.

### What changed?

Modified the Windows update command in the `update_project` function to use `System.Net.WebClient` instead of `Invoke-WebRequest`. This change replaces the previous `iwr` (alias for `Invoke-WebRequest`) command with a more explicit PowerShell method for downloading and executing scripts.

### Why make this change?

The new method provides better compatibility across different PowerShell versions and offers more control over the download process. It also enhances security by using a more explicit and standard approach to downloading and executing scripts in PowerShell.