### PR TITLE
updated publish logic

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -6,7 +6,9 @@ on:
       - '**'
   pull_request:
     branches:
-      - 'master'
+      - master
+    types:
+      - closed
 
 env:
   CARGO_TERM_COLOR: always
@@ -30,7 +32,7 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.ref == 'refs/heads/master' || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged) }}
 
     steps:
     - name: Check out the code
@@ -46,17 +48,21 @@ jobs:
         published_version=$(cargo search $(cargo pkgid | sed 's/.*#//' | cut -d: -f1) --limit 1 | grep -oP '\(\K[^)]+' | head -1)
         echo "published_version=$published_version" >> $GITHUB_ENV
 
-    - name: Compare versions
-      id: compare_versions
+    - name: Debug version variables
       run: |
-        if [ "$(echo -e "${published_version}\n${version}" | sort -V | head -n1)" != "$version" ]; then
+        echo "Current version: ${{ env.version }}"
+        echo "Published version: ${{ env.published_version }}"
+
+    - name: Compare versions
+      run: |
+        if [ "$(printf "%s\n%s" "$published_version" "$version" | sort -V | head -n1)" != "$version" ]; then
           echo "newer_version=true" >> $GITHUB_ENV
         else
           echo "newer_version=false" >> $GITHUB_ENV
+        fi
 
     - name: Publish to crates.io
       if: ${{ env.newer_version == 'true' }}
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       run: cargo publish --no-verify
-


### PR DESCRIPTION
### TL;DR

Updated GitHub Actions workflow to publish on merged pull requests to master.

### What changed?

- Modified the trigger for pull requests to only run on closed PRs.
- Updated the publish job condition to run on merged PRs to master.
- Added a debug step to print current and published versions.
- Improved version comparison logic for more accurate results.

### Why make this change?

This change streamlines the publishing process by allowing automatic releases when pull requests are merged to master. It also improves version comparison accuracy and adds debugging information for easier troubleshooting.