### PR TITLE
publish on push to master

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - '**'
-  pull_request:
-    branches:
-      - master
-    types:
-      - closed
 
 env:
   CARGO_TERM_COLOR: always
@@ -47,16 +42,14 @@ jobs:
       run: |
         # Extract the package name
         package_name=$(cargo pkgid | sed 's/.*#//; s/:.*//')
-        
-        # Get the published version by extracting the version number
+
         published_version=$(cargo search "$package_name" --limit 1 | grep -oP '=\s*"\K[^"]+')
 
-        # Check if published_version is valid
         if [ -z "$published_version" ]; then
           echo "Published version could not be found. Please ensure the package is published." >&2
           exit 1
         fi
-        
+
         echo "published_version=$published_version" >> $GITHUB_ENV
 
     - name: Debug version variables


### PR DESCRIPTION
### TL;DR

Simplified GitHub Actions workflow for building and publishing.

### What changed?

- Removed the `pull_request` trigger from the workflow.
- Streamlined the version checking process by removing unnecessary comments and simplifying the logic.

### Why make this change?

This change optimizes the workflow by:
1. Focusing on push events only, which simplifies the trigger conditions.
2. Removing redundant comments and streamlining the version checking process, making the workflow more concise and easier to maintain.