### PR TITLE
don't fail on publish failure

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -47,10 +47,10 @@ jobs:
 
         if [ -z "$published_version" ]; then
           echo "Published version could not be found. Please ensure the package is published." >&2
-          exit 1
+          echo "published_version=none" >> $GITHUB_ENV # Set to none if not found
+        else
+          echo "published_version=$published_version" >> $GITHUB_ENV
         fi
-
-        echo "published_version=$published_version" >> $GITHUB_ENV
 
     - name: Debug version variables
       run: |
@@ -59,10 +59,14 @@ jobs:
 
     - name: Compare versions
       run: |
-        if [ "$(printf "%s\n%s" "${{ env.published_version }}" "${{ env.version }}" | sort -V | head -n1)" != "${{ env.version }}" ]; then
-          echo "newer_version=true" >> $GITHUB_ENV
-        else
+        if [ "${{ env.published_version }}" == "none" ]; then
           echo "newer_version=false" >> $GITHUB_ENV
+        else
+          if [ "$(printf "%s\n%s" "${{ env.published_version }}" "${{ env.version }}" | sort -V | head -n1)" != "${{ env.version }}" ]; then
+            echo "newer_version=true" >> $GITHUB_ENV
+          else
+            echo "newer_version=false" >> $GITHUB_ENV
+          fi
         fi
 
     - name: Publish to crates.io


### PR DESCRIPTION
### TL;DR

Improved version comparison logic in the build-publish workflow.

### What changed?

- Modified the version comparison logic to handle cases where the published version is not found.
- Set `published_version` to "none" when it can't be retrieved, instead of exiting the workflow.
- Updated the version comparison step to account for the "none" case.

### Why make this change?

This change enhances the robustness of the build-publish workflow by:
1. Preventing premature workflow termination when a published version isn't found.
2. Allowing the workflow to continue and potentially publish a new package even if it's the first publication.
3. Ensuring accurate version comparison for determining whether to publish a new version.