### PR TITLE
cargo dep update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "sticks"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "clap",
 ]


### PR DESCRIPTION
### TL;DR
Bump version from 0.1.14 to 0.1.15

### What changed?
Updated version number in Cargo.lock from 0.1.14 to 0.1.15

### Why make this change?
Version bump needed to prepare for next release and maintain semantic versioning